### PR TITLE
Make it possible to let the biv in the torso be a surface or a volume

### DIFF
--- a/src/cardiac_geometries/_mesh.py
+++ b/src/cardiac_geometries/_mesh.py
@@ -195,6 +195,7 @@ def create_biv_ellipsoid(
 def create_biv_ellipsoid_torso(
     outdir: Union[str, Path, None] = None,
     char_length: float = 0.5,
+    heart_as_surface: bool = True,
     torso_length: float = 20.0,
     torso_width: float = 20.0,
     torso_height: float = 20.0,
@@ -227,6 +228,9 @@ def create_biv_ellipsoid_torso(
         directory will be created, by default None, by default None
     char_length : float, optional
         Characteristic length of mesh, by default 0.5
+    heart_as_surface: bool
+        If true, create the heart as a a surface inside the torso,
+        otherwise let the heart be a volume, by default True.
     torso_length : float, optional
         Length of torso in the x-direction, by default 20.0
     torso_width : float, optional
@@ -301,6 +305,7 @@ def create_biv_ellipsoid_torso(
         json.dump(
             {
                 "char_length": char_length,
+                "heart_as_surface": heart_as_surface,
                 "torso_length": torso_length,
                 "torso_width": torso_width,
                 "torso_height": torso_height,
@@ -337,6 +342,7 @@ def create_biv_ellipsoid_torso(
     biv_ellipsoid_torso(
         mesh_name=mesh_name.as_posix(),
         char_length=char_length,
+        heart_as_surface=heart_as_surface,
         torso_length=torso_length,
         torso_height=torso_height,
         torso_width=torso_width,

--- a/src/cardiac_geometries/cli.py
+++ b/src/cardiac_geometries/cli.py
@@ -389,6 +389,12 @@ def create_biv_ellipsoid(
     show_default=True,
 )
 @click.option(
+    "--heart-as-surface/--heart-as-volume",
+    default=True,
+    help="Whether the heart should be a surface of a volume inside the torso",
+    show_default=True,
+)
+@click.option(
     "--torso-length",
     default=20,
     type=float,
@@ -549,6 +555,7 @@ def create_biv_ellipsoid(
 def create_biv_ellipsoid_torso(
     outdir: Path,
     char_length: float = 0.5,
+    heart_as_surface: bool = True,
     torso_length: float = 20.0,
     torso_width: float = 20.0,
     torso_height: float = 20.0,
@@ -580,6 +587,7 @@ def create_biv_ellipsoid_torso(
     geo = create_biv_ellipsoid_torso(
         outdir=outdir,
         char_length=char_length,
+        heart_as_surface=heart_as_surface,
         torso_length=torso_length,
         torso_height=torso_height,
         torso_width=torso_width,


### PR DESCRIPTION
In https://github.com/ComputationalPhysiology/cardiac_geometries/pull/9 we made it possible to create a BiV inside a torso where the BiV was a surface mesh inside the torso. Here we add an option to add it as a volume mesh instead using the flag `--heart-as-surface` (default) or `--heart-as-volume`